### PR TITLE
Update KittenDB_Friends.wiki

### DIFF
--- a/docs/ru/KittenDB_Friends.wiki
+++ b/docs/ru/KittenDB_Friends.wiki
@@ -131,7 +131,7 @@ $MC_Friends->increment($key,$value);
 Возвращает значение приватности в виде [[KittenDB_Friends_Privacy.wiki#Описание приватности|строки]], не обязательно той же самой, что была использована при создании или редактировании приватности, но [[KittenDB_Friends_Privacy.wiki#Канонический вид|эквивалентной]] ей. Если указанный пользователь или приватность не определены, возвращает <code>false</code>.
 
 === Удаление приватности ===
-<code>delete("privacy{$id}_{$priv_key}");
+<code>delete("privacy{$id}_{$priv_key}");</code>
 
 === Проверка приватности ===
 <code>get("{$user_id}~{$owner_id}:{$privacy_key}")</code>


### PR DESCRIPTION
lost part of the code because the function does not display the removal of privacy
